### PR TITLE
TTS relay channel, paragraph advancement and voice persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,4 +82,4 @@ Distributed under the MIT License. See `LICENSE.md` for more information.
 
 ## Works well with
 
-- [SherpaTTS](f-droid.org/packages/org.woheller69.ttsengine/)
+- [SherpaTTS](https://f-droid.org/packages/org.woheller69.ttsengine/)

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,6 +27,7 @@
     "tts:allow-stop",
     "tts:allow-get-voices",
     "tts:allow-is-initialized",
+    "tts:allow-register-listener",
     "dialog:default",
     "http:default"
   ]

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -28,6 +28,7 @@
     "tts:allow-stop",
     "tts:allow-get-voices",
     "tts:allow-is-initialized",
+    "tts:allow-register-listener",
     "safe-area-insets-css:default",
     "dialog:default",
     "media-session:allow-update-state",

--- a/src/components/LanguageSelect.vue
+++ b/src/components/LanguageSelect.vue
@@ -2,13 +2,24 @@
 import { ref, onMounted } from 'vue'
 import { getVoices, Voice } from 'tauri-plugin-tts-api'
 import { invokeNoParseLogError } from '../composables/useTauri'
+import { getSetting, setSetting } from '../composables/useSettings'
+
+const SETTING_KEY = 'voice_id'
 
 const languages = ref<Voice[]>([])
-const voiceId = ref<string | null>(null)
+const selectedIndex = ref<number>(-1)
 
 async function loadVoices() {
   try {
     languages.value = await getVoices()
+    const saved = await getSetting(SETTING_KEY)
+    if (saved) {
+      const idx = languages.value.findIndex(v => v.id === saved)
+      if (idx !== -1) {
+        selectedIndex.value = idx
+        await invokeNoParseLogError('set_voice_id', { voiceId: saved })
+      }
+    }
   }
   catch (e) {
     console.error(`Failed to load voices: ${e}`)
@@ -18,9 +29,13 @@ async function loadVoices() {
 async function onLanguageChange(event: Event) {
   const target = event.target as HTMLSelectElement
   const index = parseInt(target.value)
-  const voice = index !== null ? languages.value[index] : null
-  voiceId.value = voice?.id ?? null
-  await invokeNoParseLogError('set_voice_id', { voiceId: voiceId.value })
+  const voice = !isNaN(index) ? languages.value[index] : null
+  const id = voice?.id ?? null
+  selectedIndex.value = index
+  await invokeNoParseLogError('set_voice_id', { voiceId: id })
+  if (id) {
+    await setSetting(SETTING_KEY, id)
+  }
 }
 
 onMounted(async () => {
@@ -31,13 +46,12 @@ onMounted(async () => {
 <template>
   <template v-if="languages.length > 0">
     <select
-      role="button"
-      class="ti"
-      style="text-align-last: center;"
+      :value="selectedIndex >= 0 ? selectedIndex : ''"
+      style="text-align-last: center; color: var(--pico-color);"
       @change="onLanguageChange"
     >
       <option
-        selected
+        value=""
         disabled
       >
         &#127760;

--- a/src/components/SpeakBar.vue
+++ b/src/components/SpeakBar.vue
@@ -191,6 +191,10 @@ onMounted(async () => {
     scrollOnFocus,
   )
   ttsEnabled.value = await loadTtsSetting()
+  // Ensure the native TTS event relay channel is set up before we start
+  // listening for speech:finish / speech:error. On mobile this registers the
+  // Kotlin → Rust → Tauri channel; on desktop it is a no-op.
+  await invokeNoParseLogError('plugin:tts|register_listener')
   await nextTick()
   await initReading()
   await loadNotificationHandlers()


### PR DESCRIPTION
## Changes

### fix(android): register TTS relay channel so speech:finish advances paragraphs
- Call `plugin:tts|register_listener` in `SpeakBar` on mount so the Kotlin→Rust Channel is set up before any `speak()` call on mobile
- Add `tts:allow-register-listener` permission to `default` and `mobile` capabilities
- Without this, `eventChannel` in Kotlin was always `null`, `speech:finish` was silently dropped, and reading never advanced past the first paragraph on Android

### fix(ui): persist voice selection and fix invisible text in LanguageSelect
- Save chosen `voice_id` to settings on change and restore it on mount
- Fix text color using `var(--pico-color)` so the selected option is visible inside the dialog regardless of theme
- Remove invalid `class="ti"` and `role="button"` from the `<select>` element

### fix: f-droid link needs http(s) to redirect